### PR TITLE
Added a missing `clipper` variable in the intersect method

### DIFF
--- a/easel.js
+++ b/easel.js
@@ -335,6 +335,8 @@ EASEL.volumeHelper = (function() {
   };
 
   intersect = function(subjectVolumes, clipVolumes, operation) {
+    var clipper = new ClipperLib.Clipper();
+
     operation = operation || ClipperLib.ClipType.ctIntersection;
 
     subjectLines = flatMap(subjectVolumes.map(toSegments));


### PR DESCRIPTION
While converting the code from a gist available at https://gist.github.com/nevernormal1/b69139572185d7a2ef2dd6d6a3ea1a23 the variable declaration of `clipper` was missed. This PR is fining this error.